### PR TITLE
download interceptor base

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -418,6 +418,10 @@
       }
     }
   },
+  "Extension_list": {
+    "message": "Intercept download of files with those extensions (space/colon separated)",
+    "description": "Header for settings section."
+  },
   "Debugging_Output": {
     "message": "Debugging Output",
     "description": "Header for settings section."

--- a/src/background/backgroundState.ts
+++ b/src/background/backgroundState.ts
@@ -11,7 +11,7 @@ export interface BackgroundState {
   notificationInterval: number | undefined;
   showNonErrorNotifications: boolean;
   isInitializingExtension: boolean;
-  extList: string,
+  interceptExtensions: string,
 }
 
 const state: BackgroundState = {
@@ -22,7 +22,7 @@ const state: BackgroundState = {
   notificationInterval: undefined,
   showNonErrorNotifications: true,
   isInitializingExtension: true,
-  extList: '',
+  interceptExtensions: '',
 };
 
 export function getMutableStateSingleton() {

--- a/src/background/backgroundState.ts
+++ b/src/background/backgroundState.ts
@@ -11,7 +11,7 @@ export interface BackgroundState {
   notificationInterval: number | undefined;
   showNonErrorNotifications: boolean;
   isInitializingExtension: boolean;
-  interceptExtensions: string,
+  interceptExtensions: string;
 }
 
 const state: BackgroundState = {

--- a/src/background/backgroundState.ts
+++ b/src/background/backgroundState.ts
@@ -11,6 +11,7 @@ export interface BackgroundState {
   notificationInterval: number | undefined;
   showNonErrorNotifications: boolean;
   isInitializingExtension: boolean;
+  extList: string,
 }
 
 const state: BackgroundState = {
@@ -21,6 +22,7 @@ const state: BackgroundState = {
   notificationInterval: undefined,
   showNonErrorNotifications: true,
   isInitializingExtension: true,
+  extList: '',
 };
 
 export function getMutableStateSingleton() {

--- a/src/background/downloadInterceptor.ts
+++ b/src/background/downloadInterceptor.ts
@@ -1,0 +1,30 @@
+import { getMutableStateSingleton } from "./backgroundState";
+import { addDownloadTasksAndPoll } from "./actions";
+
+export function initializeDownloadInterceptor() {
+  downloads.onCreated.addListener((itm)=>{
+
+    const state = getMutableStateSingleton();
+    var ext, ext_list;
+
+    ext_list = state.extList.split(' ');
+
+    // has no extension
+    if (itm.filename.index('.') < 0) return;
+
+    ext = itm.filename.split('.').pop().toLowerCase();
+
+    // extension not in the list
+    if (ext_list.indexOf(ext) < 0) return;
+
+    // stop download and add NAS task
+    downloads.cancel(itm.id);
+    addDownloadTasksAndPoll(
+      state.api,
+      state.pollRequestManager,
+      state.showNonErrorNotifications,
+      [itm.url],
+    );
+
+  });
+}

--- a/src/background/downloadInterceptor.ts
+++ b/src/background/downloadInterceptor.ts
@@ -7,7 +7,7 @@ export function initializeDownloadInterceptor() {
     const state = getMutableStateSingleton();
     var ext, ext_list;
 
-    ext_list = state.extList.split(' ');
+    ext_list = state.interceptExtensions.split(' ');
 
     // has no extension
     if (itm.filename.index('.') < 0) return;

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,9 +4,11 @@ import { saveLastSevereError } from "../common/errorHandlers";
 import { onStoredStateChange as onStoredStateChangeListener } from "./onStateChange";
 import { initializeContextMenus } from "./contextMenus";
 import { initializeMessageHandler } from "./messages";
+import { initializeDownloadInterceptor } from "./downloadInterceptor";
 
 initializeContextMenus();
 initializeMessageHandler();
+initializeDownloadInterceptor();
 
 maybeMigrateState()
   .then(() => {

--- a/src/background/onStateChange.ts
+++ b/src/background/onStateChange.ts
@@ -133,5 +133,7 @@ export function onStoredStateChange(storedState: State) {
     backgroundState.finishedTaskIds = new Set(updatedFinishedTaskIds);
   }
 
+  backgroundState.extList = storedState.settings.extList;
+
   backgroundState.isInitializingExtension = false;
 }

--- a/src/background/onStateChange.ts
+++ b/src/background/onStateChange.ts
@@ -133,7 +133,7 @@ export function onStoredStateChange(storedState: State) {
     backgroundState.finishedTaskIds = new Set(updatedFinishedTaskIds);
   }
 
-  backgroundState.extList = storedState.settings.extList;
+  backgroundState.interceptExtensions = storedState.settings.interceptExtensions;
 
   backgroundState.isInitializingExtension = false;
 }

--- a/src/common/state/listen.ts
+++ b/src/common/state/listen.ts
@@ -9,6 +9,7 @@ export const SETTING_NAMES = typesafeUnionMembers<keyof Settings>({
   shouldHandleDownloadLinks: true,
   badgeDisplayType: true,
   showInactiveTasks: true,
+  extList: true,
 });
 
 const ALL_STORED_STATE_NAMES = typesafeUnionMembers<keyof State>({

--- a/src/common/state/listen.ts
+++ b/src/common/state/listen.ts
@@ -9,7 +9,7 @@ export const SETTING_NAMES = typesafeUnionMembers<keyof Settings>({
   shouldHandleDownloadLinks: true,
   badgeDisplayType: true,
   showInactiveTasks: true,
-  extList: true,
+  interceptExtensions: true,
 });
 
 const ALL_STORED_STATE_NAMES = typesafeUnionMembers<keyof State>({

--- a/src/settings/SettingsForm.tsx
+++ b/src/settings/SettingsForm.tsx
@@ -173,7 +173,7 @@ export class SettingsForm extends React.PureComponent<Props, State> {
                   .split(' ')
                   .filter((s)=>{ return s; })
                   .join(' ');
-                this.saveExtList("interceptExtensions", interceptExtensions);
+                this.saveExtList(interceptExtensions);
               }}
             />
           </div>

--- a/src/settings/SettingsForm.tsx
+++ b/src/settings/SettingsForm.tsx
@@ -160,6 +160,23 @@ export class SettingsForm extends React.PureComponent<Props, State> {
               DOWNLOAD_ONLY_PROTOCOLS.join(", "),
             ])}
           />
+
+          <span className="label">{browser.i18n.getMessage("Extension_list")}</span>
+          <div className="input">
+            <input
+              type="text"
+              value={this.props.extensionState.settings.extList}
+              onChange={(e) => {
+                var extList = e.currentTarget.value
+                  .replace(/[\;\,\.]/g,' ')// unify various separators into spaces
+                  .toLowerCase()
+                  .split(' ')
+                  .filter((s)=>{ return s; })
+                  .join(' ');
+                this.saveExtList("extList", extList);
+              }}
+            />
+          </div>
         </SettingsList>
 
         {this.maybeRenderDebuggingOutputAndSeparator()}
@@ -262,6 +279,12 @@ export class SettingsForm extends React.PureComponent<Props, State> {
   private setShouldHandleDownloadLinks(shouldHandleDownloadLinks: boolean) {
     this.saveSettings({
       shouldHandleDownloadLinks,
+    });
+  }
+
+  private saveExtList(extList: string) {
+    this.saveSettings({
+      extList,
     });
   }
 

--- a/src/settings/SettingsForm.tsx
+++ b/src/settings/SettingsForm.tsx
@@ -165,15 +165,15 @@ export class SettingsForm extends React.PureComponent<Props, State> {
           <div className="input">
             <input
               type="text"
-              value={this.props.extensionState.settings.extList}
+              value={this.props.extensionState.settings.interceptExtensions}
               onChange={(e) => {
-                var extList = e.currentTarget.value
+                var interceptExtensions = e.currentTarget.value
                   .replace(/[\;\,\.]/g,' ')// unify various separators into spaces
                   .toLowerCase()
                   .split(' ')
                   .filter((s)=>{ return s; })
                   .join(' ');
-                this.saveExtList("extList", extList);
+                this.saveExtList("interceptExtensions", interceptExtensions);
               }}
             />
           </div>
@@ -282,9 +282,9 @@ export class SettingsForm extends React.PureComponent<Props, State> {
     });
   }
 
-  private saveExtList(extList: string) {
+  private saveExtList(interceptExtensions: string) {
     this.saveSettings({
-      extList,
+      interceptExtensions,
     });
   }
 


### PR DESCRIPTION
This should be able to intercept browser downloads of files with given extensions, cancel them and make tasks on NAS.
Unfortunately I wasn't able to test this, as I've got following error in last stage of yarn :
```
error /mnt/sd/usr/src/nas-download-manager/node_modules/deasync: Command failed.
Exit code: 1
Command: node ./build.js
Arguments: 
Directory: /mnt/sd/usr/src/nas-download-manager/node_modules/deasync
Output:
events.js:291
      throw er; // Unhandled 'error' event
      ^

Error: spawn node-gyp ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:268:19)
    at onErrorNT (internal/child_process.js:470:16)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:274:12)
    at onErrorNT (internal/child_process.js:470:16)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  errno: 'ENOENT',
  code: 'ENOENT',
  syscall: 'spawn node-gyp',
  path: 'node-gyp',
  spawnargs: [ 'rebuild' ]
}
```