### PR TITLE
Add two-factor (OTP) login support with device-token persistence

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -548,6 +548,14 @@
     "message": "Two-step verification failed.",
     "description": "Error message on Synology API call failure."
   },
+  "Twostep_verification_code": {
+    "message": "2FA code",
+    "description": "Label for the two-step verification (OTP) input on the settings page."
+  },
+  "Twostep_verification_code_placeholder": {
+    "message": "Only if 2-step verification is enabled",
+    "description": "Placeholder for the two-step verification code input on the settings page."
+  },
   "File_upload_failed": {
     "message": "File upload failed.",
     "description": "Error message on Synology API call failure."

--- a/src/background/onStateChange.ts
+++ b/src/background/onStateChange.ts
@@ -16,6 +16,8 @@ export function onStoredStateChange(storedState: State) {
     baseUrl: getHostUrl(storedState.settings.connection),
     account: storedState.settings.connection.username,
     session: SessionName.DownloadStation,
+    // The remembered 2FA device token (if any) lets the background log in without an OTP prompt.
+    deviceToken: storedState.settings.connection.rememberedDeviceToken,
     // Do NOT set password from here. It might not be set because of the "remember me" feature, so
     // we could erroneously overwrite it. Instead, read it once at startup time (if configured), and
     // otherwise, wait for an imperative login request message to be handled elsewhere.

--- a/src/common/apis/connection.ts
+++ b/src/common/apis/connection.ts
@@ -1,14 +1,18 @@
 import { ConnectionSettings, getHostUrl } from "../state";
 import { ClientRequestResult, SessionName, SynologyClient } from "./synology";
+import type { AuthLoginResponse } from "./synology/Auth";
 
 export async function testConnection(
   settings: ConnectionSettings,
-): Promise<ClientRequestResult<{}>> {
+  otpCode?: string,
+): Promise<ClientRequestResult<AuthLoginResponse>> {
   const api = new SynologyClient({
     baseUrl: getHostUrl(settings),
     account: settings.username,
     passwd: settings.password,
     session: SessionName.DownloadStation,
+    otpCode,
+    deviceToken: settings.rememberedDeviceToken,
   });
 
   const loginResult = await api.Auth.Login({ timeout: 30000 });

--- a/src/common/apis/synology/Auth.ts
+++ b/src/common/apis/synology/Auth.ts
@@ -9,11 +9,24 @@ export interface AuthLoginRequest extends BaseRequest {
   session: SessionName;
   // 2 is the lowest version that actually provides an sid.
   // 3 is the lowest version that DSM 7 supports.
-  version: 2 | 3;
+  // 6 is the lowest version that supports device tokens (enable_device_token / device_id),
+  // which is how we remember a 2FA login so the user only types their code once.
+  version: 2 | 3 | 6;
+  // The 6-digit two-factor code. Only needed on the first login for a 2FA-enabled account
+  // (or when the remembered device token is no longer accepted).
+  otp_code?: string;
+  // Ask DSM to issue a device token we can reuse to skip future OTP prompts.
+  enable_device_token?: "yes" | "no";
+  // A human-readable name shown in DSM's trusted-devices list.
+  device_name?: string;
+  // A previously-issued device token, presented instead of an OTP on later logins.
+  device_id?: string;
 }
 
 export interface AuthLoginResponse {
   sid: string;
+  // Present when enable_device_token=yes and login succeeded; persist and reuse as device_id.
+  did?: string;
 }
 
 export interface AuthLogoutRequest extends BaseRequest {

--- a/src/common/apis/synology/client.ts
+++ b/src/common/apis/synology/client.ts
@@ -18,19 +18,37 @@ const NO_SUCH_METHOD_ERROR_CODE = 103;
 const NO_PERMISSIONS_ERROR_CODE = 105;
 const SESSION_TIMEOUT_ERROR_CODE = 106;
 
+// Shown in DSM's Control Panel > Security > Account > trusted devices list.
+const DEVICE_NAME = "NAS Download Manager";
+
 export interface SynologyClientSettings {
   baseUrl: string;
   account: string;
   passwd: string;
   session: SessionName;
+  // 2FA one-time-password, used only for a single login (the first one on a 2FA account).
+  otpCode?: string;
+  // A remembered device token ("did") presented in lieu of an OTP on subsequent logins.
+  deviceToken?: string;
 }
 
-const SETTING_NAME_KEYS = typesafeUnionMembers<keyof SynologyClientSettings>({
+// The fields that must be present for the connection to be considered configured. The 2FA
+// fields above are deliberately excluded — they're optional and account-dependent.
+type RequiredSettingName = "baseUrl" | "account" | "passwd" | "session";
+
+const SETTING_NAME_KEYS = typesafeUnionMembers<RequiredSettingName>({
   baseUrl: true,
   account: true,
   passwd: true,
   session: true,
 });
+
+// A change to any of these should tear down the current session and force a fresh login.
+const SESSION_RESET_KEYS: (keyof SynologyClientSettings)[] = [
+  ...SETTING_NAME_KEYS,
+  "deviceToken",
+  "otpCode",
+];
 
 export type ConnectionFailure =
   | {
@@ -85,7 +103,7 @@ export class SynologyClient {
 
   public partiallyUpdateSettings(settings: Partial<SynologyClientSettings>) {
     const updatedSettings = { ...this.settings, ...settings };
-    if (SETTING_NAME_KEYS.some((k) => updatedSettings[k] !== this.settings[k])) {
+    if (SESSION_RESET_KEYS.some((k) => updatedSettings[k] !== this.settings[k])) {
       this.settingsVersion++;
       this.settings = updatedSettings;
       this.maybeLogout();
@@ -115,28 +133,39 @@ export class SynologyClient {
     if (isConnectionFailure(settings)) {
       return settings;
     } else if (!this.loginPromise) {
-      const { baseUrl, ...restSettings } = settings;
-      this.loginPromise = Auth.Login(baseUrl, {
-        ...request,
-        ...restSettings,
-        // First try with the lowest version that we can that supports sid, in an attempt to
-        // support the oldest DSMs we can.
-        version: 2,
-      })
-        .then((response) => {
-          // We guess we're on DSM 7, which does not support earlier versions of the API.
-          // We'd like to do this with an Info.Query, but DSM 7 erroneously reports that it
-          // supports version 2, which it definitely does not.
-          if (!response.success && response.error.code === NO_SUCH_METHOD_ERROR_CODE) {
-            return Auth.Login(baseUrl, {
-              ...request,
-              ...restSettings,
-              version: 3,
-            });
-          } else {
-            return response;
-          }
-        })
+      const { baseUrl, account, passwd, session, otpCode, deviceToken } = settings;
+
+      // Note: only camelCased fields known to Auth.Login are forwarded — never spread the whole
+      // settings object, or otpCode/deviceToken would leak into the query string verbatim.
+      const attempt = (version: 2 | 3 | 6) =>
+        Auth.Login(baseUrl, {
+          ...request,
+          account,
+          passwd,
+          session,
+          version,
+          // Always ask DSM to (re)issue a device token so we can keep skipping the OTP prompt.
+          enable_device_token: "yes",
+          device_name: DEVICE_NAME,
+          // Prefer a freshly-typed OTP; otherwise present a remembered device token, if any.
+          otp_code: otpCode || undefined,
+          device_id: !otpCode && deviceToken ? deviceToken : undefined,
+        });
+
+      // 6 is the lowest version supporting device tokens, so try it first. Fall back through
+      // 3 then 2 for older DSMs that don't implement it (they report code 103, no-such-method).
+      // DSM 7 erroneously claims to support version 2, so we can't rely on Info.Query here.
+      this.loginPromise = attempt(6)
+        .then((response) =>
+          !response.success && response.error.code === NO_SUCH_METHOD_ERROR_CODE
+            ? attempt(3)
+            : response,
+        )
+        .then((response) =>
+          !response.success && response.error.code === NO_SUCH_METHOD_ERROR_CODE
+            ? attempt(2)
+            : response,
+        )
         .catch((e) => ConnectionFailure.from(e));
     }
 

--- a/src/common/state/migrations/8.ts
+++ b/src/common/state/migrations/8.ts
@@ -1,0 +1,45 @@
+import type { OmitStrict } from "../../types";
+
+import type { State as State_7, Settings as Settings_7, ConnectionSettings as ConnectionSettings_7 } from "./7";
+
+export {
+  VisibleTaskSettings,
+  TaskSortType,
+  NotificationSettings,
+  CachedTasks,
+  Logging,
+  BadgeDisplayType,
+} from "./7";
+
+export interface StateVersion {
+  stateVersion: 8;
+}
+
+export interface ConnectionSettings extends ConnectionSettings_7 {
+  // The device token ("did") DSM returns when you log in with enable_device_token=yes after
+  // passing a 2FA one-time-password. Presenting it on later logins lets us skip the OTP prompt.
+  // Undefined when 2FA is off or this device hasn't been remembered yet.
+  rememberedDeviceToken: string | undefined;
+}
+
+export interface Settings extends OmitStrict<Settings_7, "connection"> {
+  connection: ConnectionSettings;
+}
+
+export interface State extends StateVersion, OmitStrict<State_7, "settings" | "stateVersion"> {
+  settings: Settings;
+}
+
+export function migrate(state: State_7): State {
+  return {
+    ...state,
+    stateVersion: 8,
+    settings: {
+      ...state.settings,
+      connection: {
+        ...state.settings.connection,
+        rememberedDeviceToken: undefined,
+      },
+    },
+  };
+}

--- a/src/common/state/migrations/latest.ts
+++ b/src/common/state/migrations/latest.ts
@@ -9,4 +9,4 @@ export {
   Logging,
   StateVersion,
   BadgeDisplayType,
-} from "./7";
+} from "./8";

--- a/src/common/state/migrations/update.ts
+++ b/src/common/state/migrations/update.ts
@@ -6,8 +6,9 @@ import { migrate as migrate3to4 } from "./4";
 import { migrate as migrate4to5 } from "./5";
 import { migrate as migrate5to6 } from "./6";
 import { migrate as migrate6to7 } from "./7";
+import { migrate as migrate7to8 } from "./8";
 
-const LATEST_STATE_VERSION: StateVersion["stateVersion"] = 7;
+const LATEST_STATE_VERSION: StateVersion["stateVersion"] = 8;
 const MIGRATIONS: ((state: any) => any)[] = [
   migrate0to1,
   migrate1to2,
@@ -16,6 +17,7 @@ const MIGRATIONS: ((state: any) => any)[] = [
   migrate4to5,
   migrate5to6,
   migrate6to7,
+  migrate7to8,
 ];
 
 interface AnyStateVersion {

--- a/src/settings/ConnectionSettings.tsx
+++ b/src/settings/ConnectionSettings.tsx
@@ -25,12 +25,15 @@ interface Props {
 interface State {
   changedSettings: Partial<ConnectionSettingsWithMandatoryPassword>;
   loginStatus: Status;
+  // Transient 2FA code — used for a single login and never persisted.
+  otpCode: string;
 }
 
 export class ConnectionSettings extends React.PureComponent<Props, State> {
   state: State = {
     changedSettings: {},
     loginStatus: "none",
+    otpCode: "",
   };
 
   render() {
@@ -117,6 +120,27 @@ export class ConnectionSettings extends React.PureComponent<Props, State> {
             <label htmlFor={checkboxId}>{browser.i18n.getMessage("Remember_Password")}</label>
           </li>
 
+          <li className="label-and-input">
+            <span className="label">{browser.i18n.getMessage("Twostep_verification_code")}</span>
+            <div className="input">
+              <input
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                maxLength={6}
+                placeholder={browser.i18n.getMessage("Twostep_verification_code_placeholder")}
+                {...disabledPropAndClassName(!canEditFields)}
+                value={this.state.otpCode}
+                onChange={(e) => {
+                  this.setState({
+                    loginStatus: "none",
+                    otpCode: e.currentTarget.value.replace(/[^0-9]/g, ""),
+                  });
+                }}
+              />
+            </div>
+          </li>
+
           <li>
             <LoginStatus status={this.state.loginStatus} />
             <button
@@ -166,14 +190,20 @@ export class ConnectionSettings extends React.PureComponent<Props, State> {
       loginStatus: "in-progress",
     });
 
-    const result = await testConnection(settings);
+    const otpCode = this.state.otpCode.trim();
+    const result = await testConnection(settings, otpCode || undefined);
 
     this.setState({
       loginStatus: result,
     });
 
     if (!ClientRequestResult.isConnectionFailure(result) && result.success) {
-      this.props.saveConnectionSettings(settings);
+      // DSM returns a device token ("did") when we log in with enable_device_token after a 2FA
+      // code. Persist it so subsequent logins skip the OTP prompt; keep any existing token if
+      // none came back (e.g. accounts without 2FA).
+      const rememberedDeviceToken = result.data.did ?? settings.rememberedDeviceToken;
+      this.props.saveConnectionSettings({ ...settings, rememberedDeviceToken });
+      this.setState({ otpCode: "" });
     }
   };
 }


### PR DESCRIPTION
## Summary

Adds two-factor (OTP) login support so accounts with **2-step verification** can sign in. Today a password-only login on such an account returns API error `403` ("two-step needed") with no way to supply the code, so the extension can't connect at all.

## How it works

DSM 7's `SYNO.API.Auth` (version ≥ 6) supports **device tokens**:

1. First login sends `account` + `passwd` + `otp_code` + `enable_device_token=yes` → DSM returns `{ sid, did }`.
2. The `did` is persisted as `connection.rememberedDeviceToken` (new state migration `8`).
3. Subsequent logins send `device_id=<did>` instead of an OTP, so the user only types a code **once**.

The login path now tries version `6` first (device-token capable) and falls back to `3` → `2` for older DSMs (which report code `103`).

## Changes

- **`Auth.ts`** — `otp_code` / `enable_device_token` / `device_name` / `device_id` request fields; `did` in the response; `version: 2 | 3 | 6`.
- **`client.ts`** — optional `otpCode` / `deviceToken` client settings (excluded from the "is configured" check); version-6-first login with fallback; session reset when the token changes.
- **`connection.ts`** — `testConnection(settings, otpCode?)` forwards the OTP + remembered token and returns the login response (with `did`).
- **`ConnectionSettings.tsx`** — a **2FA code** field that persists the returned device token on success. (Adds two `_locales` strings; the `Twostep_verification_*` error messages already existed but were unreachable.)
- **`state/migrations/8.ts`** (+ `latest.ts`, `update.ts`) — adds `connection.rememberedDeviceToken`.
- **`onStateChange.ts`** — feeds the remembered token to the background client.

## Notes / limitations

- Accounts **without** 2FA are unaffected — the field is optional and no token is issued.
- The popup's password form (shown only when "Remember password" is off) has no OTP field; set up the connection via **Settings** with "Remember password" on, and the popup/background then work silently via the device token.
- Tested against **DSM 7.2.2** + Download Station with 2-step verification enabled. `tsc -p src --noemit` passes.
